### PR TITLE
Update iperf3 to support SCTP protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,43 @@ ADD super_netperf   /sbin/
 ADD percpu_netperf  /sbin/
 ADD latency_netperf /sbin/
 
-RUN											   \
-	apk add --update curl wrk iperf3 git build-base texinfo bash iproute2 automake     \
-			 libtool intltool autoconf					&& \
-	git clone https://github.com/HewlettPackard/netperf.git				&& \
-	cd netperf/									&& \
-	./autogen.sh									&& \
-	chmod a+x configure								&& \
-	./configure --prefix=/usr							&& \
-	make										&& \
-	make install									&& \
-	cd ..										&& \
-	rm -rf netperf									&& \
-	rm -f /usr/share/info/netperf.info						&& \
-	strip -s /usr/bin/netperf /usr/bin/netserver					&& \
-	apk del build-base texinfo git automake libtool intltool autoconf		&& \
-	rm -rf /var/cache/apk/*
+# The CFLAGS=-fcommon - https://gcc.gnu.org/gcc-10/porting_to.html
+# Fixes: multiple definition of `loc_nodelay'; nettest_bsd.o:./src/nettest_bsd.c:206: first defined here
+RUN	apk add --update \
+	curl \
+	wrk \
+	git \
+	build-base \
+	texinfo \
+	bash \
+	iproute2 \
+	automake \
+	libtool \
+	intltool \
+	autoconf \
+	lksctp-tools-dev \
+	linux-headers \
+	&& git clone https://github.com/HewlettPackard/netperf.git \
+	&& cd netperf/ \
+	&& git checkout 3bc455b \
+	&& ./autogen.sh	\
+	&& chmod a+x configure \
+	&& ./configure --prefix=/usr CFLAGS=-fcommon \
+	&& make \
+	&& make install \
+	&& cd .. \
+	&& git clone --depth 1 --branch 3.9 https://github.com/esnet/iperf.git \
+	&& cd iperf \
+	&& ./configure --prefix=/usr \
+	&& make \
+	&& make install \
+	&& cd .. \
+	&& rm -rf netperf \
+	&& rm -rf iperf \
+	&& rm -f /usr/share/info/netperf.info \
+	&& strip -s /usr/bin/netperf /usr/bin/netserver \
+	&& apk del build-base texinfo git automake libtool intltool autoconf linux-headers \
+	&& rm -rf /var/cache/apk/*
 
 EXPOSE 12865
 


### PR DESCRIPTION
- Adds `lksctp-tools-dev`, `linux-headers` package
- Changes `iperf3` to be compiled from source code
- Formats Dockerfile based on [Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)

Signed-off-by: Thiago Navarro <navarro@accuknox.com>